### PR TITLE
Add console script for run_cddd.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ scikit-learn
 ```
 ### Conda
 Create a new enviorment:
-```
+```bash
 git clone https://github.com/jrwnter/cddd.git
 cd cddd
 conda env create –f environment.yml
@@ -27,13 +27,13 @@ pip install .
 
 ### Downloading Pretrained Model
 A pretrained model as described in ref. 1 is available on Google Drive. Download and unzip by execuiting the bash script "download_default_model.sh":
-```
+```bash
 ./download_default_model.sh
 ```
 The default_model.zip file can also be downloaded manualy under https://drive.google.com/open?id=1oyknOulq_j0w9kzOKKIHdTLo5HphT99h
 ### Testing
 Extract molecular descriptors from two QSAR datasets (ref. 2,3) and evaluate the perfromance of a SVM trained on these descriptors.
-```
+```bash
 cd example
 python3 run_qsar_test.py
 ```
@@ -44,8 +44,8 @@ The r2 on the Lipophilicity dataset should be arround 0.731 +/- 0.029.
 ## Getting Started
 ### Extracting Molecular Descripotrs
 Run the script run_cddd.py to extract molecular descripotrs of your provided SMILES:
-```
-run_cddd.py --input smiles.smi --output descriptors.csv  --smiles_header smiles
+```bash
+cddd --input smiles.smi --output descriptors.csv  --smiles_header smiles
 ```
 Supported input: 
   * .csv-file with one SMILES per row
@@ -55,27 +55,27 @@ For .csv: Specify the header of the SMILES column with the flag --smiles_header 
 
 ### Inference Module
 The pretrained model can also be imported and used directly in python via the inference class:
-```
+```python
 import pandas as pd
 from cddd.inference import InferenceModel
 from cddd.preprocessing import preprocess_smiles
 ```
 Load and preprocess data:
-```
+```python
 ames_df = pd.read_csv("example/ames.csv", index_col=0)
 ames_df["smiles_preprocessed"] = ames_df.smiles.map(preprocess_smiles)
 smiles_list = ames_df["smiles_preprocessed"].tolist()
 ```
 Create a instance of the inference class:
-```
+```python
 inference_model = InferenceModel()
 ```
 Encode all SMILES into the continuous embedding (molecular descriptor):
-```
+```python
 smiles_embedding = inference_model.seq_to_emb(smiles_list)
 ```
 The infernce model instance can also be used to decode a molecule embedding back to a interpretable SMILES string:
-```
+```python
 decoded_smiles_list = inference_model.emb_to_seq(smiles_embedding)
 ```
 ### References

--- a/cddd/run_cddd.py
+++ b/cddd/run_cddd.py
@@ -87,8 +87,11 @@ def main(unused_argv):
     print("writing descriptors to file...")
     df.to_csv(FLAGS.output)
 
-if __name__ == "__main__":
+def main_wrapper():
     PARSER = argparse.ArgumentParser()
     add_arguments(PARSER)
     FLAGS, UNPARSED = PARSER.parse_known_args()
     tf.app.run(main=main, argv=[sys.argv[0]] + UNPARSED)
+    
+if __name__ == "__main__":
+    main_wrapper()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
    #install_requires=['tensorflow'], #external packages as dependencies
    entry_points={
       'console_scripts': [
-        'cddd = cddd.run_cddd:main',
+        'cddd = cddd.run_cddd:main_wrapper',
     ],
    },
 )

--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,9 @@ setup(
    package_data={'cddd': ['data/*', 'default_model/*']},
    include_package_data=True,
    #install_requires=['tensorflow'], #external packages as dependencies
+   entry_points={
+      'console_scripts': [
+        'cddd = cddd.run_cddd:main',
+    ],
+   },
 )


### PR DESCRIPTION
This PR gives `setuptools` extra information so it knows how to turn `cddd/run_cddd.py` into a command line script that can be run from any working directory without explicitly writing the path to the python script using the `entry_points` option and the magical `console_scripts` key. 

The entry in the list `'cddd = cddd.run_cddd:main_wrapper'` means that a script called `cddd` will be installed and it will run the function found in the `cddd.run_cddd` called `main_wrapper` as the `__main__`. Since the code that did the work was already living inside the `if __name__ == '__main__':` construct, I excised it and put it inside a new function called `main_wrapper` and called that from `if __name__ == '__main__':` . This way, everything will continue to work as before, as well.

Finally, I updated the readme to reflect this change (and also added a bit of code highlighting, while I was editing it)