### PR TITLE
Update environment.yml to install all dependencies in a single step

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,29 +16,21 @@ rdkit
 scikit-learn
 ```
 ### Conda
-Create a new enviorment:
+Create a new environment:
 ```bash
-git clone https://github.com/jrwnter/cddd.git
-cd cddd
 conda env create -f environment.yml
-source activate cddd
+conda activate cddd
 ```
-Install tensorflow without GPU support:
+Using the specification in the `environment.yml` file in the prior step, tensorflow is installed without GPU support; to optionally install tensorflow with GPU support (available only on Linux or Windows, not MacOS):
 ```bash
-pip install --ignore-installed --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.10.0-cp36-cp36m-linux_x86_64.whl
-```
-Or with GPU support:
-```bash
-pip install --ignore-installed --upgrade https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.10.0-cp36-cp36m-linux_x86_64.whl
-```
-And install the cddd package:
-```bash
-pip install .
+conda install -c conda-forge tensorflow-gpu=1.10.0
 ```
 
 ### Downloading Pretrained Model
 A pretrained model as described in ref. 1 is available on Google Drive. Download and unzip by execuiting the bash script "download_default_model.sh":
 ```bash
+git clone https://github.com/jrwnter/cddd
+cd cddd
 ./download_default_model.sh
 ```
 The default_model.zip file can also be downloaded manualy under https://drive.google.com/open?id=1oyknOulq_j0w9kzOKKIHdTLo5HphT99h

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,14 @@
 name: cddd
-
 channels:
   - rdkit
+  - conda-forge
   - defaults
-
 dependencies:
+  - anaconda::pip
   - anaconda::python=3.6
   - rdkit::rdkit=2018.03.3.0
   - anaconda::scikit-learn=0.19.1
+  - conda-forge::tensorflow=1.10.0
+  - pip:
+    - git+https://github.com/jrwnter/cddd.git
+


### PR DESCRIPTION
This PR provides an updated `environment.yml` to permit the installation of all dependencies in a single step.

In particular, the need to separately install tensorflow via pip is eliminated (by leveraging the solution proposed by @t-kimber in issue #13) and the need to install cddd via multiple steps is eliminated (by pip-installing directly from the git repo on Github).

This PR also provides a minimalistic update to the README to reflect these changes in the installation instructions.

These changes were tested on MacOS 10.15.7 and Ubuntu 18.04.5 LTS (Linux).

Hope this helps make it easier for others to quickly install cddd.